### PR TITLE
Make derivations compatible with aeson

### DIFF
--- a/elm-bridge.cabal
+++ b/elm-bridge.cabal
@@ -1,5 +1,6 @@
 name:                elm-bridge
-version:             0.1.0.0
+version:             0.2.1
+x-revision: 1
 synopsis:            Derive Elm types from Haskell types
 description:         Building the bridge from Haskell to Elm and back. Define types once,
                      use on both sides and enjoy easy (de)serialisation. Cheers!
@@ -17,16 +18,34 @@ extra-source-files:
     README.md
     examples/*.hs
 
+
 library
   hs-source-dirs:      src
+  ghc-options:         -Wall
   exposed-modules:
                        Elm.Derive
                        Elm.Json
                        Elm.Module
                        Elm.TyRender
                        Elm.TyRep
+  other-modules:       Elm.Utils
   build-depends:       base >= 4.7 && < 5,
-                       template-haskell
+                       template-haskell,
+-- There is a known bug in aeson 0.10.0.0 that is triggered by the derivation
+-- function in some cases: https://github.com/bos/aeson/issues/293
+                       aeson  == 0.9.*
+  default-language:    Haskell2010
+
+test-suite end-to-end-tests
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             EndToEnd.hs
+  build-depends:       base,
+                       elm-bridge,
+                       aeson,
+                       containers,
+                       QuickCheck,
+                       text
   default-language:    Haskell2010
 
 test-suite derive-elm-tests
@@ -42,7 +61,9 @@ test-suite derive-elm-tests
   build-depends:
                        base,
                        hspec >= 2.0,
-                       elm-bridge
+                       elm-bridge,
+                       aeson,
+                       containers
   default-language:    Haskell2010
 
 source-repository head

--- a/examples/Helpers.elm
+++ b/examples/Helpers.elm
@@ -1,0 +1,84 @@
+module Json.Bridge.Helpers where
+
+import Dict exposing (Dict)
+import Set exposing (Set)
+import Json.Encode
+import Json.Decode exposing ((:=), Value)
+
+type ObjectEncoding = EObject (List (String, Value)) | EValue Value
+
+oeValue : ObjectEncoding -> Value
+oeValue x = case x of
+    EObject o -> Json.Encode.object o
+    EValue  v -> v
+
+maybe : b -> (a -> b) -> Maybe a -> b
+maybe n j m = case m of
+    Nothing -> n
+    Just a -> j a
+
+resmapM : (a -> Result r b) -> List a -> Result r (List b)
+resmapM f lst = case lst of
+   [] -> Ok []
+   (x :: xs) -> f x `Result.andThen` \nx -> resmapM f xs `Result.andThen` \nxs -> Ok (nx :: nxs)
+
+
+decodeSumObjectWithSingleField : String -> Dict String (Json.Decode.Decoder a) -> Json.Decode.Decoder a
+decodeSumObjectWithSingleField name mapping = Json.Decode.keyValuePairs Json.Decode.value `Json.Decode.customDecoder` \lst -> case lst of
+    [(key,value)] -> decodeSumFinal name key value mapping
+    _ -> Err ("Can't decode " ++ name ++ ": object has too many keys")
+
+decodeSumTwoElemArray : String -> Dict String (Json.Decode.Decoder a) -> Json.Decode.Decoder a
+decodeSumTwoElemArray name mapping = Json.Decode.tuple2 (,) Json.Decode.string Json.Decode.value `Json.Decode.customDecoder`
+    \(key, value) -> decodeSumFinal name key value mapping
+
+decodeSumTaggedObject : String -> String -> String -> Dict String (Json.Decode.Decoder a) -> Set String -> Json.Decode.Decoder a
+decodeSumTaggedObject name fieldname contentname mapping objectKeys =
+    (fieldname := Json.Decode.string) `Json.Decode.andThen` \key ->
+        let decoder = if Set.member key objectKeys
+                         then Json.Decode.value
+                         else contentname := Json.Decode.value
+        in  decoder `Json.Decode.customDecoder` \value -> decodeSumFinal name key value mapping
+
+decodeSumFinal : String -> String -> Value -> Dict String (Json.Decode.Decoder a) -> Result String a
+decodeSumFinal name key value mapping =
+    case Dict.get key mapping of
+        Nothing -> Err ("Unknown constructor " ++ key ++ " for type " ++ name)
+        Just dec -> Json.Decode.decodeValue dec value
+
+encodeSumObjectWithSingleField : (a -> (String, ObjectEncoding)) -> a -> Value
+encodeSumObjectWithSingleField mkkeyval v =
+    let (key, val) = mkkeyval v
+    in  Json.Encode.object [ (key, oeValue val) ]
+
+encodeSumTwoElementArray : (a -> (String, ObjectEncoding)) -> a -> Value
+encodeSumTwoElementArray mkkeyval v =
+   let (key, val) = mkkeyval v
+   in  Json.Encode.list [ Json.Encode.string key, oeValue val ]
+
+encodeSumTaggedObject : String -> String -> (a -> (String, ObjectEncoding)) -> a -> Value
+encodeSumTaggedObject fieldname contentname mkkeyval v =
+   let (key, eval) = mkkeyval v
+       kp = (fieldname, Json.Encode.string key)
+   in  case eval of
+        EValue  val -> Json.Encode.object [ kp, (contentname, val) ]
+        EObject obj -> Json.Encode.object ( kp :: obj )
+
+decodeSumUnaries : String -> Dict String a -> Json.Decode.Decoder a
+decodeSumUnaries typename mapping = Json.Decode.string `Json.Decode.andThen` \s -> case Dict.get s mapping of
+    Nothing -> Json.Decode.fail ("Could not decode " ++ typename)
+    Just x -> Json.Decode.succeed x
+
+decodeMap : Json.Decode.Decoder comparable -> Json.Decode.Decoder v -> Json.Decode.Decoder (Dict comparable v)
+decodeMap decKey decVal =
+    let decodeKeys = resmapM decodeKey
+        decodeKey (k, v) = Result.map (\nk -> (nk,v)) (Json.Decode.decodeString decKey k)
+    in  Json.Decode.map Dict.fromList (Json.Decode.keyValuePairs decVal `Json.Decode.customDecoder` decodeKeys)
+
+encodeMap : (comparable -> Json.Encode.Value) -> (v -> Json.Encode.Value) -> Dict comparable v -> Json.Encode.Value
+encodeMap encKey encVal =
+    let encKey' x = case Json.Decode.decodeValue Json.Decode.string (encKey x) of
+            Err _ -> toString x
+            Ok s -> s
+    in  Json.Encode.object << List.map (\(k,v) -> (encKey' k, encVal v)) << Dict.toList
+

--- a/src/Elm/Module.hs
+++ b/src/Elm/Module.hs
@@ -15,13 +15,18 @@ data DefineElm
 
 -- | Compile an Elm module
 makeElmModule :: String -> [DefineElm] -> String
-makeElmModule moduleName defs =
-    "module " ++ moduleName ++ " where \n\n"
-    ++ "import Json.Decode\n"
-    ++ "import Json.Decode exposing ((:=))\n"
-    ++ "import Json.Encode\n"
-    ++ "\n\n"
-    ++ intercalate "\n\n" (map mkDef defs)
+makeElmModule moduleName defs = unlines (
+    [ "module " ++ moduleName ++ " where"
+    , ""
+    , "import Json.Decode"
+    , "import Json.Decode exposing ((:=))"
+    , "import Json.Encode"
+    , ""
+    , ""
+    ]) ++ makeModuleContent defs
+
+makeModuleContent :: [DefineElm] -> String
+makeModuleContent = intercalate "\n\n" . map mkDef
     where
       mkDef (DefineElm proxy) =
           let def = compileElmDef proxy

--- a/src/Elm/Utils.hs
+++ b/src/Elm/Utils.hs
@@ -1,0 +1,13 @@
+module Elm.Utils where
+
+import Data.Char (toUpper)
+
+cap :: String -> String
+cap "" = ""
+cap (x:xs) = toUpper x : xs
+
+fixReserved :: String -> String
+fixReserved x = case x of
+                    "in"   -> "in_"
+                    "type" -> "type_"
+                    _      -> x

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,32 @@
-flags: {}
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: nightly-2015-11-04
+
+# Local packages, usually specified by relative directory name
 packages:
 - '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps: []
-resolver: lts-2.20
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/test/Elm/JsonSpec.hs
+++ b/test/Elm/JsonSpec.hs
@@ -9,6 +9,9 @@ import Elm.TestHelpers
 
 import Data.Proxy
 import Test.Hspec
+import Data.Char (toLower)
+import Data.Aeson.Types (SumEncoding(..))
+import qualified Data.Map.Strict as M
 
 data Foo
    = Foo
@@ -28,39 +31,184 @@ data SomeOpts a
    = Okay Int
    | NotOkay a
 
+data UnaryA = UnaryA1 | UnaryA2
+data UnaryB = UnaryB1 | UnaryB2
+
+data Change a = Change { _before :: a, _after :: a }
+
+data Baz a = Baz1 { _foo :: Int, _qux :: M.Map Int a }
+           | Baz2 { _bar :: Maybe Int, _str :: String }
+           | Zob a
+
+data TestComp a = TestComp { _t1 :: Change Int
+                           , _t2 :: Change a
+                           }
+
+-- TODO
+data Qux a = Qux1 { _quxfoo :: Int, _quxqux :: a }
+           | Qux2 Int (M.Map Int a)
+
 $(deriveElmDef (fieldDropOpts 2) ''Foo)
 $(deriveElmDef (fieldDropOpts 2) ''Bar)
-$(deriveElmDef defaultOpts ''SomeOpts)
+$(deriveElmDef (fieldDropOpts 1) ''TestComp)
+$(deriveElmDef defaultOptions ''SomeOpts)
+$(deriveElmDef defaultOptions{ allNullaryToStringTag = False } ''UnaryA)
+$(deriveElmDef defaultOptions{ allNullaryToStringTag = True  } ''UnaryB)
+$(deriveElmDef defaultOptions { fieldLabelModifier = drop 1 . map toLower } ''Baz)
+$(deriveElmDef defaultOptions { fieldLabelModifier = drop 4 . map toLower, sumEncoding = TaggedObject "tag" "value" } ''Qux)
 
 fooSer :: String
-fooSer = "jsonEncFoo  val = \n   Json.Encode.object\n   [ (\"name\", Json.Encode.string val.name)\n   , (\"blablub\", Json.Encode.int val.blablub)\n   ]\n"
+fooSer = "jsonEncFoo  val =\n   Json.Encode.object\n   [ (\"name\", Json.Encode.string val.name)\n   , (\"blablub\", Json.Encode.int val.blablub)\n   ]\n"
 
 fooParse :: String
-fooParse = "jsonDecFoo  = \n   (\"name\" := Json.Decode.string) `Json.Decode.andThen` \\pname -> \n   (\"blablub\" := Json.Decode.int) `Json.Decode.andThen` \\pblablub -> \n   Json.Decode.succeed {name = pname, blablub = pblablub}\n"
+fooParse = unlines
+    [ "jsonDecFoo : Json.Decode.Decoder ( Foo )"
+    , "jsonDecFoo ="
+    , "   (\"name\" := Json.Decode.string) `Json.Decode.andThen` \\pname -> "
+    , "   (\"blablub\" := Json.Decode.int) `Json.Decode.andThen` \\pblablub -> "
+    , "   Json.Decode.succeed {name = pname, blablub = pblablub}"
+    ]
 
 barSer :: String
-barSer = "jsonEncBar localEncoder_a val = \n   Json.Encode.object\n   [ (\"name\", localEncoder_a val.name)\n   , (\"blablub\", Json.Encode.int val.blablub)\n   , (\"tuple\", (\\v1 v2 -> [(Json.Encode.int) v1,(Json.Encode.string) v2] val.tuple)\n   , (\"list\", (Json.Encode.list << map Json.Encode.bool) val.list)\n   ]\n"
+barSer = unlines
+    [ "jsonEncBar localEncoder_a val ="
+    , "   Json.Encode.object"
+    , "   [ (\"name\", localEncoder_a val.name)"
+    , "   , (\"blablub\", Json.Encode.int val.blablub)"
+    , "   , (\"tuple\", (\\v1 v2 -> [(Json.Encode.int) v1,(Json.Encode.string) v2]) val.tuple)"
+    , "   , (\"list\", (Json.Encode.list << List.map Json.Encode.bool) val.list)"
+    , "   ]"
+    ]
+
+bazSer :: String
+bazSer = unlines
+    [ "jsonEncBaz localEncoder_a val ="
+    , "    let keyval v = case v of"
+    , "                    Baz1 vs -> (\"Baz1\", EObject [(\"foo\", Json.Encode.int vs.foo), (\"qux\", encodeMap (Json.Encode.int) (localEncoder_a) vs.qux)])"
+    , "                    Baz2 vs -> (\"Baz2\", EObject [(\"bar\", (maybe Json.Encode.null (Json.Encode.int)) vs.bar), (\"str\", Json.Encode.string vs.str)])"
+    , "                    Zob v1 -> (\"Zob\", EValue (localEncoder_a v1))"
+    , "    in encodeSumObjectWithSingleField keyval val"
+    ]
 
 barParse :: String
-barParse = "jsonDecBar localDecoder_a = \n   (\"name\" := localDecoder_a) `Json.Decode.andThen` \\pname -> \n   (\"blablub\" := Json.Decode.int) `Json.Decode.andThen` \\pblablub -> \n   (\"tuple\" := Json.Decode.tuple2 (,) (Json.Decode.int) (Json.Decode.string)) `Json.Decode.andThen` \\ptuple -> \n   (\"list\" := Json.Decode.list (Json.Decode.bool)) `Json.Decode.andThen` \\plist -> \n   Json.Decode.succeed {name = pname, blablub = pblablub, tuple = ptuple, list = plist}\n"
+barParse = unlines
+    [ "jsonDecBar : Json.Decode.Decoder a -> Json.Decode.Decoder ( Bar a )"
+    , "jsonDecBar localDecoder_a ="
+    , "   (\"name\" := localDecoder_a) `Json.Decode.andThen` \\pname -> "
+    , "   (\"blablub\" := Json.Decode.int) `Json.Decode.andThen` \\pblablub -> "
+    , "   (\"tuple\" := Json.Decode.tuple2 (,) (Json.Decode.int) (Json.Decode.string)) `Json.Decode.andThen` \\ptuple -> "
+    , "   (\"list\" := Json.Decode.list (Json.Decode.bool)) `Json.Decode.andThen` \\plist -> "
+    , "   Json.Decode.succeed {name = pname, blablub = pblablub, tuple = ptuple, list = plist}"
+    ]
+
+bazParse :: String
+bazParse = unlines
+    [ "jsonDecBaz : Json.Decode.Decoder a -> Json.Decode.Decoder ( Baz a )"
+    , "jsonDecBaz localDecoder_a = "
+    , "    let jsonDecDictBaz = Dict.fromList"
+    , "            [ (\"Baz1\", Json.Decode.map Baz1 (   (\"foo\" := Json.Decode.int) `Json.Decode.andThen` \\pfoo ->     (\"qux\" := decodeMap (Json.Decode.int) (localDecoder_a)) `Json.Decode.andThen` \\pqux ->     Json.Decode.succeed {foo = pfoo, qux = pqux}))"
+    , "            , (\"Baz2\", Json.Decode.map Baz2 (   (Json.Decode.maybe (\"bar\" := Json.Decode.int)) `Json.Decode.andThen` \\pbar ->     (\"str\" := Json.Decode.string) `Json.Decode.andThen` \\pstr ->     Json.Decode.succeed {bar = pbar, str = pstr}))"
+    , "            , (\"Zob\", Json.Decode.map Zob (localDecoder_a))"
+    , "            ]"
+    , "    in  decodeSumObjectWithSingleField  \"Baz\" jsonDecDictBaz"
+    ]
+
+quxParse :: String
+quxParse = unlines
+    [ "jsonDecQux localDecoder_a = "
+    , "   "
+    ]
 
 someOptsParse :: String
-someOptsParse = "jsonDecSomeOpts localDecoder_a = \n   Json.Decode.oneOf \n   [ (\"Okay\" := Json.tuple1 Okay (Json.Decode.int))\n   , (\"NotOkay\" := Json.tuple1 NotOkay (localDecoder_a))\n   ]\n"
+someOptsParse = unlines
+    [ "jsonDecSomeOpts : Json.Decode.Decoder a -> Json.Decode.Decoder ( SomeOpts a )"
+    , "jsonDecSomeOpts localDecoder_a = "
+    , "    let jsonDecDictSomeOpts = Dict.fromList"
+    , "            [ (\"Okay\", Json.Decode.map Okay (Json.Decode.int))"
+    , "            , (\"NotOkay\", Json.Decode.map NotOkay (localDecoder_a))"
+    , "            ]"
+    , "    in  decodeSumObjectWithSingleField  \"SomeOpts\" jsonDecDictSomeOpts"
+    ]
 
 someOptsSer :: String
-someOptsSer = "jsonEncSomeOpts localEncoder_a val = \n   case val of\n      Okay v1 -> [Json.Encode.int v1]\n      NotOkay v1 -> [localEncoder_a v1]\n"
+someOptsSer = unlines
+    [ "jsonEncSomeOpts localEncoder_a val ="
+    , "    let keyval v = case v of"
+    , "                    Okay v1 -> (\"Okay\", EValue (Json.Encode.int v1))"
+    , "                    NotOkay v1 -> (\"NotOkay\", EValue (localEncoder_a v1))"
+    , "    in encodeSumObjectWithSingleField keyval val"
+    ]
+
+test1Parse :: String
+test1Parse = unlines
+    [ "jsonDecTestComp : Json.Decode.Decoder a -> Json.Decode.Decoder ( TestComp a )"
+    , "jsonDecTestComp localDecoder_a ="
+    , "   (\"t1\" := jsonDecChange (Json.Decode.int)) `Json.Decode.andThen` \\pt1 -> "
+    , "   (\"t2\" := jsonDecChange (localDecoder_a)) `Json.Decode.andThen` \\pt2 -> "
+    , "   Json.Decode.succeed {t1 = pt1, t2 = pt2}"
+    ]
+
+unaryAParse :: String
+unaryAParse = unlines
+    [ "jsonDecUnaryA : Json.Decode.Decoder ( UnaryA )"
+    , "jsonDecUnaryA = "
+    , "    let jsonDecDictUnaryA = Dict.fromList"
+    , "            [ (\"UnaryA1\", Json.Decode.tuple0 UnaryA1 )"
+    , "            , (\"UnaryA2\", Json.Decode.tuple0 UnaryA2 )"
+    , "            ]"
+    , "    in  decodeSumObjectWithSingleField  \"UnaryA\" jsonDecDictUnaryA"
+    ]
+
+unaryBParse :: String
+unaryBParse = unlines
+    [ "jsonDecUnaryB : Json.Decode.Decoder ( UnaryB )"
+    , "jsonDecUnaryB = decodeSumUnaries \"UnaryB\" jsonDecDictUnaryB"
+    , "jsonDecDictUnaryB = Dict.fromList [(\"UnaryB1\", UnaryB1), (\"UnaryB2\", UnaryB2)]"
+    ]
+
+unaryASer :: String
+unaryASer = unlines
+    [ "jsonEncUnaryA  val ="
+    , "    let keyval v = case v of"
+    , "                    UnaryA1  -> (\"UnaryA1\", EValue (Json.Encode.list []))"
+    , "                    UnaryA2  -> (\"UnaryA2\", EValue (Json.Encode.list []))"
+    , "    in encodeSumObjectWithSingleField keyval val"
+    ]
+
+unaryBSer :: String
+unaryBSer = unlines
+    [ "jsonEncUnaryB  val ="
+    , "    case val of"
+    , "        UnaryB1 -> Json.Encode.string \"UnaryB1\""
+    , "        UnaryB2 -> Json.Encode.string \"UnaryB2\""
+    ]
 
 spec :: Spec
 spec =
     describe "json serialisation" $
     do let rFoo = compileElmDef (Proxy :: Proxy Foo)
            rBar = compileElmDef (Proxy :: Proxy (Bar a))
+           rBaz = compileElmDef (Proxy :: Proxy (Baz a))
+           rQux = compileElmDef (Proxy :: Proxy (Qux a))
+           rTest1 = compileElmDef (Proxy :: Proxy (TestComp a))
            rSomeOpts = compileElmDef (Proxy :: Proxy (SomeOpts a))
-       it "should produce the correct ser code" $
-          do jsonSerForDef rFoo `shouldBe` fooSer
+           rUnaryA = compileElmDef (Proxy :: Proxy UnaryA)
+           rUnaryB = compileElmDef (Proxy :: Proxy UnaryB)
+       it "should produce the correct ser code" $ do
+             jsonSerForDef rFoo `shouldBe` fooSer
              jsonSerForDef rBar `shouldBe` barSer
              jsonSerForDef rSomeOpts `shouldBe` someOptsSer
-       it "should produce the correct parse code" $
-          do jsonParserForDef rFoo `shouldBe` fooParse
+             jsonSerForDef rBaz `shouldBe` bazSer
+       it "should produce the correct ser code for unary unions" $ do
+             jsonSerForDef rUnaryA `shouldBe` unaryASer
+             jsonSerForDef rUnaryB `shouldBe` unaryBSer
+       it "should produce the correct parse code for aliases" $ do
+             jsonParserForDef rFoo `shouldBe` fooParse
              jsonParserForDef rBar `shouldBe` barParse
+       it "should produce the correct parse code generic sum types" $ do
+             jsonParserForDef rBaz `shouldBe` bazParse
              jsonParserForDef rSomeOpts `shouldBe` someOptsParse
+             jsonParserForDef rTest1 `shouldBe` test1Parse
+       it "should produce the correct parse code for unary unions" $ do
+             jsonParserForDef rUnaryA `shouldBe` unaryAParse
+             jsonParserForDef rUnaryB `shouldBe` unaryBParse

--- a/test/Elm/ModuleSpec.hs
+++ b/test/Elm/ModuleSpec.hs
@@ -17,15 +17,81 @@ data Bar a
    , b_list :: [Bool]
    } deriving (Show, Eq)
 
+data Qux a = Qux1 Int String
+           | Qux2 { _qux2a :: Int, _qux2test :: a }
+           deriving (Show, Eq)
+
 $(deriveElmDef (fieldDropOpts 2) ''Bar)
+$(deriveElmDef (fieldDropOpts 5) ''Qux)
 
 moduleCode :: String
-moduleCode = "module Foo where \n\nimport Json.Decode\nimport Json.Decode exposing ((:=))\nimport Json.Encode\n\n\ntype alias Bar a = \n   { name: a\n   , blablub: Int\n   , tuple: (Int, String)\n   , list: (List Bool)\n   }\n\njsonDecBar localDecoder_a = \n   (\"name\" := localDecoder_a) `Json.Decode.andThen` \\pname -> \n   (\"blablub\" := Json.Decode.int) `Json.Decode.andThen` \\pblablub -> \n   (\"tuple\" := Json.Decode.tuple2 (,) (Json.Decode.int) (Json.Decode.string)) `Json.Decode.andThen` \\ptuple -> \n   (\"list\" := Json.Decode.list (Json.Decode.bool)) `Json.Decode.andThen` \\plist -> \n   Json.Decode.succeed {name = pname, blablub = pblablub, tuple = ptuple, list = plist}\n\njsonEncBar localEncoder_a val = \n   Json.Encode.object\n   [ (\"name\", localEncoder_a val.name)\n   , (\"blablub\", Json.Encode.int val.blablub)\n   , (\"tuple\", (\\v1 v2 -> [(Json.Encode.int) v1,(Json.Encode.string) v2] val.tuple)\n   , (\"list\", (Json.Encode.list << map Json.Encode.bool) val.list)\n   ]\n\n"
+moduleCode = unlines
+    [ "module Foo where"
+    , ""
+    , "import Json.Decode"
+    , "import Json.Decode exposing ((:=))"
+    , "import Json.Encode"
+    , ""
+    , ""
+    , "type alias Bar a = "
+    , "   { name: a"
+    , "   , blablub: Int"
+    , "   , tuple: (Int, String)"
+    , "   , list: (List Bool)"
+    , "   }"
+    , ""
+    , "jsonDecBar : Json.Decode.Decoder a -> Json.Decode.Decoder ( Bar a )"
+    , "jsonDecBar localDecoder_a ="
+    , "   (\"name\" := localDecoder_a) `Json.Decode.andThen` \\pname -> "
+    , "   (\"blablub\" := Json.Decode.int) `Json.Decode.andThen` \\pblablub -> "
+    , "   (\"tuple\" := Json.Decode.tuple2 (,) (Json.Decode.int) (Json.Decode.string)) `Json.Decode.andThen` \\ptuple -> "
+    , "   (\"list\" := Json.Decode.list (Json.Decode.bool)) `Json.Decode.andThen` \\plist -> "
+    , "   Json.Decode.succeed {name = pname, blablub = pblablub, tuple = ptuple, list = plist}"
+    , ""
+    , "jsonEncBar localEncoder_a val ="
+    , "   Json.Encode.object"
+    , "   [ (\"name\", localEncoder_a val.name)"
+    , "   , (\"blablub\", Json.Encode.int val.blablub)"
+    , "   , (\"tuple\", (\\v1 v2 -> [(Json.Encode.int) v1,(Json.Encode.string) v2]) val.tuple)"
+    , "   , (\"list\", (Json.Encode.list << List.map Json.Encode.bool) val.list)"
+    , "   ]"
+    , ""
+    ]
+
+moduleCode' :: String
+moduleCode' = unlines
+    [ "module Qux where"
+    , ""
+    , "import Json.Decode"
+    , "import Json.Decode exposing ((:=))"
+    , "import Json.Encode"
+    , ""
+    , ""
+    , "type Qux a = "
+    , "    Qux1 Int String"
+    , "    | Qux2 {a: Int, test: a}"
+    , ""
+    , "jsonDecQux : Json.Decode.Decoder a -> Json.Decode.Decoder ( Qux a )"
+    , "jsonDecQux localDecoder_a = "
+    , "    let jsonDecDictQux = Dict.fromList"
+    , "            [ (\"Qux1\", Json.Decode.tuple2 Qux1 (Json.Decode.int) (Json.Decode.string))"
+    , "            , (\"Qux2\", Json.Decode.map Qux2 (   (\"a\" := Json.Decode.int) `Json.Decode.andThen` \\pa ->     (\"test\" := localDecoder_a) `Json.Decode.andThen` \\ptest ->     Json.Decode.succeed {a = pa, test = ptest}))"
+    , "            ]"
+    , "    in  decodeSumObjectWithSingleField  \"Qux\" jsonDecDictQux"
+    , ""
+    , "jsonEncQux localEncoder_a val ="
+    , "    let keyval v = case v of"
+    , "                    Qux1 v1 v2 -> (\"Qux1\", EValue (Json.Encode.list [Json.Encode.int v1, Json.Encode.string v2]))"
+    , "                    Qux2 vs -> (\"Qux2\", EObject [(\"a\", Json.Encode.int vs.a), (\"test\", localEncoder_a vs.test)])"
+    , "    in encodeSumObjectWithSingleField keyval val"
+    , ""
+    ]
 
 spec :: Spec
 spec =
     describe "makeElmModule" $
     it "should produce the correct code" $
-       do let modu =
-                 makeElmModule "Foo" [DefineElm (Proxy :: Proxy (Bar a))]
+       do let modu = makeElmModule "Foo" [DefineElm (Proxy :: Proxy (Bar a))]
+          let modu' = makeElmModule "Qux" [DefineElm (Proxy :: Proxy (Qux a))]
           modu `shouldBe` moduleCode
+          modu' `shouldBe` moduleCode'

--- a/test/Elm/TestHelpers.hs
+++ b/test/Elm/TestHelpers.hs
@@ -2,8 +2,8 @@ module Elm.TestHelpers where
 
 import Elm.Derive
 
-fieldDropOpts :: Int -> DeriveOpts
+fieldDropOpts :: Int -> Options
 fieldDropOpts i =
-    defaultOpts
-    { do_fieldModifier = drop i
+    defaultOptions
+    { fieldLabelModifier = drop i
     }

--- a/test/Elm/TyRenderSpec.hs
+++ b/test/Elm/TyRenderSpec.hs
@@ -30,7 +30,7 @@ data SomeOpts a
 
 $(deriveElmDef (fieldDropOpts 2) ''Foo)
 $(deriveElmDef (fieldDropOpts 2) ''Bar)
-$(deriveElmDef defaultOpts ''SomeOpts)
+$(deriveElmDef defaultOptions ''SomeOpts)
 
 fooCode :: String
 fooCode = "type alias Foo  = \n   { name: String\n   , blablub: Int\n   }\n"

--- a/test/EndToEnd.hs
+++ b/test/EndToEnd.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Main where
+
+import Elm.Derive
+import Elm.Module
+import Data.Proxy
+import Data.Aeson hiding (defaultOptions)
+import Data.Aeson.Types (SumEncoding(..))
+import Test.QuickCheck.Arbitrary
+import Test.QuickCheck.Gen (sample', oneof, Gen)
+import qualified Data.Text as T
+import Control.Applicative
+import Prelude
+
+data Record1 a = Record1 { _r1foo :: Int, _r1bar :: Maybe Int, _r1baz :: a, _r1qux :: Maybe a } deriving Show
+data Record2 a = Record2 { _r2foo :: Int, _r2bar :: Maybe Int, _r2baz :: a, _r2qux :: Maybe a } deriving Show
+
+data Sum01 a = Sum01A a | Sum01B (Maybe a) | Sum01C a a | Sum01D { _s01foo :: a } | Sum01E { _s01bar :: Int, _s01baz :: Int } deriving Show
+data Sum02 a = Sum02A a | Sum02B (Maybe a) | Sum02C a a | Sum02D { _s02foo :: a } | Sum02E { _s02bar :: Int, _s02baz :: Int } deriving Show
+data Sum03 a = Sum03A a | Sum03B (Maybe a) | Sum03C a a | Sum03D { _s03foo :: a } | Sum03E { _s03bar :: Int, _s03baz :: Int } deriving Show
+data Sum04 a = Sum04A a | Sum04B (Maybe a) | Sum04C a a | Sum04D { _s04foo :: a } | Sum04E { _s04bar :: Int, _s04baz :: Int } deriving Show
+data Sum05 a = Sum05A a | Sum05B (Maybe a) | Sum05C a a | Sum05D { _s05foo :: a } | Sum05E { _s05bar :: Int, _s05baz :: Int } deriving Show
+data Sum06 a = Sum06A a | Sum06B (Maybe a) | Sum06C a a | Sum06D { _s06foo :: a } | Sum06E { _s06bar :: Int, _s06baz :: Int } deriving Show
+data Sum07 a = Sum07A a | Sum07B (Maybe a) | Sum07C a a | Sum07D { _s07foo :: a } | Sum07E { _s07bar :: Int, _s07baz :: Int } deriving Show
+data Sum08 a = Sum08A a | Sum08B (Maybe a) | Sum08C a a | Sum08D { _s08foo :: a } | Sum08E { _s08bar :: Int, _s08baz :: Int } deriving Show
+data Sum09 a = Sum09A a | Sum09B (Maybe a) | Sum09C a a | Sum09D { _s09foo :: a } | Sum09E { _s09bar :: Int, _s09baz :: Int } deriving Show
+data Sum10 a = Sum10A a | Sum10B (Maybe a) | Sum10C a a | Sum10D { _s10foo :: a } | Sum10E { _s10bar :: Int, _s10baz :: Int } deriving Show
+data Sum11 a = Sum11A a | Sum11B (Maybe a) | Sum11C a a | Sum11D { _s11foo :: a } | Sum11E { _s11bar :: Int, _s11baz :: Int } deriving Show
+data Sum12 a = Sum12A a | Sum12B (Maybe a) | Sum12C a a | Sum12D { _s12foo :: a } | Sum12E { _s12bar :: Int, _s12baz :: Int } deriving Show
+
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 3, omitNothingFields = False } ''Record1)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 3, omitNothingFields = True  } ''Record2)
+
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = False, allNullaryToStringTag = False, sumEncoding = TaggedObject "tag" "content" } ''Sum01)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = True , allNullaryToStringTag = False, sumEncoding = TaggedObject "tag" "content" } ''Sum02)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = False, allNullaryToStringTag = True , sumEncoding = TaggedObject "tag" "content" } ''Sum03)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = True , allNullaryToStringTag = True , sumEncoding = TaggedObject "tag" "content" } ''Sum04)
+
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = False, allNullaryToStringTag = False, sumEncoding = ObjectWithSingleField } ''Sum05)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = True , allNullaryToStringTag = False, sumEncoding = ObjectWithSingleField } ''Sum06)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = False, allNullaryToStringTag = True , sumEncoding = ObjectWithSingleField } ''Sum07)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = True , allNullaryToStringTag = True , sumEncoding = ObjectWithSingleField } ''Sum08)
+
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = False, allNullaryToStringTag = False, sumEncoding = TwoElemArray } ''Sum09)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = True , allNullaryToStringTag = False, sumEncoding = TwoElemArray } ''Sum10)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = False, allNullaryToStringTag = True , sumEncoding = TwoElemArray } ''Sum11)
+$(deriveBoth defaultOptions{ fieldLabelModifier = drop 4, omitNothingFields = True , allNullaryToStringTag = True , sumEncoding = TwoElemArray } ''Sum12)
+
+instance Arbitrary a => Arbitrary (Record1 a) where
+    arbitrary = Record1 <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+instance Arbitrary a => Arbitrary (Record2 a) where
+    arbitrary = Record2 <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+arb :: Arbitrary a => (a -> b) -> (Maybe a -> b) -> (a -> a -> b) -> (a -> b) -> (Int -> Int -> b) -> Gen b
+arb c1 c2 c3 c4 c5 = oneof
+    [ c1 <$> arbitrary
+    , c2 <$> arbitrary
+    , c3 <$> arbitrary <*> arbitrary
+    , c4 <$> arbitrary
+    , c5 <$> arbitrary <*> arbitrary
+    ]
+
+instance Arbitrary a => Arbitrary (Sum01 a) where arbitrary = arb Sum01A Sum01B Sum01C Sum01D Sum01E
+instance Arbitrary a => Arbitrary (Sum02 a) where arbitrary = arb Sum02A Sum02B Sum02C Sum02D Sum02E
+instance Arbitrary a => Arbitrary (Sum03 a) where arbitrary = arb Sum03A Sum03B Sum03C Sum03D Sum03E
+instance Arbitrary a => Arbitrary (Sum04 a) where arbitrary = arb Sum04A Sum04B Sum04C Sum04D Sum04E
+instance Arbitrary a => Arbitrary (Sum05 a) where arbitrary = arb Sum05A Sum05B Sum05C Sum05D Sum05E
+instance Arbitrary a => Arbitrary (Sum06 a) where arbitrary = arb Sum06A Sum06B Sum06C Sum06D Sum06E
+instance Arbitrary a => Arbitrary (Sum07 a) where arbitrary = arb Sum07A Sum07B Sum07C Sum07D Sum07E
+instance Arbitrary a => Arbitrary (Sum08 a) where arbitrary = arb Sum08A Sum08B Sum08C Sum08D Sum08E
+instance Arbitrary a => Arbitrary (Sum09 a) where arbitrary = arb Sum09A Sum09B Sum09C Sum09D Sum09E
+instance Arbitrary a => Arbitrary (Sum10 a) where arbitrary = arb Sum10A Sum10B Sum10C Sum10D Sum10E
+instance Arbitrary a => Arbitrary (Sum11 a) where arbitrary = arb Sum11A Sum11B Sum11C Sum11D Sum11E
+instance Arbitrary a => Arbitrary (Sum12 a) where arbitrary = arb Sum12A Sum12B Sum12C Sum12D Sum12E
+
+elmModuleContent :: String
+elmModuleContent = unlines
+    [ "module MyTests where"
+    , ""
+    , "import Dict exposing(Dict)"
+    , "import Json.Decode exposing ((:=), Value)"
+    , "import Json.Encode"
+    , "import Json.Bridge.Helpers exposing (..)"
+    , "import ElmTest exposing (..)"
+    , "import Graphics.Element exposing (Element)"
+    , "import String"
+    , ""
+    , "main : Element"
+    , "main = elementRunner <| suite \"Testing\" [ sumEncode, sumDecode ]"
+    ,""
+    , "sumDecode : Test"
+    , "sumDecode = suite \"Sum decoding checks\""
+    , "              [ sumDecode01"
+    , "              , sumDecode02"
+    , "              , sumDecode03"
+    , "              , sumDecode04"
+    , "              , sumDecode05"
+    , "              , sumDecode06"
+    , "              , sumDecode07"
+    , "              , sumDecode08"
+    , "              , sumDecode09"
+    , "              , sumDecode10"
+    , "              , sumDecode11"
+    , "              , sumDecode12"
+    , "              ]"
+    , ""
+    , "sumEncode : Test"
+    , "sumEncode = suite \"Sum encoding checks\""
+    , "              [ sumEncode01"
+    , "              , sumEncode02"
+    , "              , sumEncode03"
+    , "              , sumEncode04"
+    , "              , sumEncode05"
+    , "              , sumEncode06"
+    , "              , sumEncode07"
+    , "              , sumEncode08"
+    , "              , sumEncode09"
+    , "              , sumEncode10"
+    , "              , sumEncode11"
+    , "              , sumEncode12"
+    , "              ]"
+    , ""
+    , "-- this is done to prevent artificial differences due to object ordering, this is hacky as hell :("
+    , "assertEqualHack : String -> String -> Assertion"
+    , "assertEqualHack a b ="
+    , "    let remix = String.map replaceSpecial >> String.split \",\" >> List.sort"
+    , "        replaceSpecial c = case c of"
+    , "            '{' -> ','"
+    , "            '}' -> ','"
+    , "            '[' -> ','"
+    , "            ']' -> ','"
+    , "            x   -> x"
+    , "    in assertEqual (remix a) (remix b)"
+    , ""
+    , makeModuleContent
+        [ DefineElm (Proxy :: Proxy (Record1 a))
+        , DefineElm (Proxy :: Proxy (Record2 a))
+        , DefineElm (Proxy :: Proxy (Sum01 a))
+        , DefineElm (Proxy :: Proxy (Sum02 a))
+        , DefineElm (Proxy :: Proxy (Sum03 a))
+        , DefineElm (Proxy :: Proxy (Sum04 a))
+        , DefineElm (Proxy :: Proxy (Sum05 a))
+        , DefineElm (Proxy :: Proxy (Sum06 a))
+        , DefineElm (Proxy :: Proxy (Sum07 a))
+        , DefineElm (Proxy :: Proxy (Sum08 a))
+        , DefineElm (Proxy :: Proxy (Sum09 a))
+        , DefineElm (Proxy :: Proxy (Sum10 a))
+        , DefineElm (Proxy :: Proxy (Sum11 a))
+        , DefineElm (Proxy :: Proxy (Sum12 a))
+        ]
+    ]
+
+mkSumDecodeTest :: (Show a, ToJSON a) => String -> [a] -> String
+mkSumDecodeTest num elems = unlines (
+    [ "sumDecode" ++ num ++ " : Test"
+    , "sumDecode" ++ num ++ " = suite \"sum decode " ++ num ++ "\""
+    ]
+    ++ map mktest (zip ([1..] :: [Int]) elems)
+    ++ ["  ]"]
+    )
+  where
+      mktest (n,e) = prefix ++ "test \"" ++ show n ++ "\" (assertEqual (Json.Decode.decodeString (jsonDecSum" ++ num ++ " Json.Decode.int) " ++ encoded ++ ") (Ok (" ++ pretty ++ ")))"
+        where
+            pretty = T.unpack $ T.replace (T.pack ("_s" ++ num)) T.empty $ T.pack $ show e
+            encoded = show (encode e)
+            prefix = if n == 1 then "  [ " else "  , "
+
+mkSumEncodeTest :: (Show a, ToJSON a) => String -> [a] -> String
+mkSumEncodeTest num elems = unlines (
+    [ "sumEncode" ++ num ++ " : Test"
+    , "sumEncode" ++ num ++ " = suite \"sum encode " ++ num ++ "\""
+    ]
+    ++ map mktest (zip ([1..] :: [Int]) elems)
+    ++ ["  ]"]
+    )
+  where
+      mktest (n,e) = prefix ++ "test \"" ++ show n ++ "\" (assertEqualHack (Json.Encode.encode 0 (jsonEncSum" ++ num ++ " Json.Encode.int (" ++ pretty ++ "))) " ++ encoded ++ ")"
+        where
+            pretty = T.unpack $ T.replace (T.pack ("_s" ++ num)) T.empty $ T.pack $ show e
+            encoded = show (encode e)
+            prefix = if n == 1 then "  [ " else "  , "
+
+main :: IO ()
+main = do
+    ss01 <- sample' arbitrary :: IO [Sum01 Int]
+    ss02 <- sample' arbitrary :: IO [Sum02 Int]
+    ss03 <- sample' arbitrary :: IO [Sum03 Int]
+    ss04 <- sample' arbitrary :: IO [Sum04 Int]
+    ss05 <- sample' arbitrary :: IO [Sum05 Int]
+    ss06 <- sample' arbitrary :: IO [Sum06 Int]
+    ss07 <- sample' arbitrary :: IO [Sum07 Int]
+    ss08 <- sample' arbitrary :: IO [Sum08 Int]
+    ss09 <- sample' arbitrary :: IO [Sum09 Int]
+    ss10 <- sample' arbitrary :: IO [Sum10 Int]
+    ss11 <- sample' arbitrary :: IO [Sum11 Int]
+    ss12 <- sample' arbitrary :: IO [Sum12 Int]
+    putStrLn $ unlines [ elmModuleContent
+                       , mkSumEncodeTest "01" ss01
+                       , mkSumEncodeTest "02" ss02
+                       , mkSumEncodeTest "03" ss03
+                       , mkSumEncodeTest "04" ss04
+                       , mkSumEncodeTest "05" ss05
+                       , mkSumEncodeTest "06" ss06
+                       , mkSumEncodeTest "07" ss07
+                       , mkSumEncodeTest "08" ss08
+                       , mkSumEncodeTest "09" ss09
+                       , mkSumEncodeTest "10" ss10
+                       , mkSumEncodeTest "11" ss11
+                       , mkSumEncodeTest "12" ss12
+                       , mkSumDecodeTest "01" ss01
+                       , mkSumDecodeTest "02" ss02
+                       , mkSumDecodeTest "03" ss03
+                       , mkSumDecodeTest "04" ss04
+                       , mkSumDecodeTest "05" ss05
+                       , mkSumDecodeTest "06" ss06
+                       , mkSumDecodeTest "07" ss07
+                       , mkSumDecodeTest "08" ss08
+                       , mkSumDecodeTest "09" ss09
+                       , mkSumDecodeTest "10" ss10
+                       , mkSumDecodeTest "11" ss11
+                       , mkSumDecodeTest "12" ss12
+                       ]
+
+


### PR DESCRIPTION
Patch description
-----------------------

This is a large patch that is intended to make derivations as close as
those from Data.Aeson as possible.

It replaces the custom settings from `elm-bridge` with that of `aeson`.

The derived elm code currently requires a few helper functions that
reside in the `examples/Helpers.elm` file. This was decided to make the
template Haskell code simpler and easier to generate and to have quick
results.

This patch also introduces a big `QuickCheck` based test to increase
confidence in the quality of the code. It generates an Elm file that
runs tests.

Notes
--------

This is my first foray with template Haskell, and I started with `elm` two days ago, so expect non optimal solutions... I don't know what happened with the cabal file, and will look into it.

Meanwhile, please give me some feedback on this change. It surely is invasive, and I am not happy with what I did in the TH code (why did I need to write the `optSumType` function ?).

I am however pretty happy with the `EndToEnd` test approach, and will try to add more use cases to it. If you have an idea on how to check encoding in a non-hacky way, I am all ears (there are differences between `aeson` and `Json.Encode` with the ordering of dictionary keys).