### PR TITLE
Updated for Elm 0.17

### DIFF
--- a/elm-bridge.cabal
+++ b/elm-bridge.cabal
@@ -28,6 +28,7 @@ library
                        Elm.Module
                        Elm.TyRender
                        Elm.TyRep
+                       Elm.Versions
   other-modules:       Elm.Utils
   build-depends:       base >= 4.7 && < 5,
                        template-haskell,

--- a/src/Elm/Module.hs
+++ b/src/Elm/Module.hs
@@ -24,7 +24,7 @@ makeElmModule :: String -- ^ Module name
               -> [DefineElm] -- ^ List of definitions to be included in the module
               -> String
 makeElmModule moduleName defs = unlines (
-    [ "module " ++ moduleName ++ " where"
+    [ "module " ++ moduleName ++ " exposing(..)"
     , ""
     , "import Json.Decode"
     , "import Json.Decode exposing ((:=))"

--- a/src/Elm/Module.hs
+++ b/src/Elm/Module.hs
@@ -13,18 +13,28 @@ import Control.Arrow (second, (+++))
 import Elm.TyRep
 import Elm.TyRender
 import Elm.Json
+import Elm.Versions
 
 -- | Existential quantification wrapper for lists of type definitions
 data DefineElm
    = forall a. IsElmDefinition a => DefineElm (Proxy a)
 
--- | Creates an Elm module. This will use the default type conversion rules (to
--- convert @Vector@ to @List@, @HashMap a b@ to @List (a,b)@, etc.).
-makeElmModule :: String -- ^ Module name
-              -> [DefineElm] -- ^ List of definitions to be included in the module
-              -> String
-makeElmModule moduleName defs = unlines (
-    [ "module " ++ moduleName ++ " where"
+-- | The module header line for this version of Elm
+moduleHeader :: ElmVersion
+             -> String
+             -> String
+moduleHeader Elm0p16 moduleName = "module " ++ moduleName ++ " where"
+moduleHeader Elm0p17 moduleName = "module " ++ moduleName ++ " exposing(..)"
+
+-- | Creates an Elm module for the given version. This will use the default
+-- type conversion rules (to -- convert @Vector@ to @List@, @HashMap a b@
+-- to @List (a,b)@, etc.).
+makeElmModuleWithVersion :: ElmVersion 
+                         -> String  -- ^ Module name
+                         -> [DefineElm]  -- ^ List of definitions to be included in the module
+                         -> String
+makeElmModuleWithVersion elmVersion moduleName defs = unlines (
+    [ moduleHeader elmVersion moduleName
     , ""
     , "import Json.Decode"
     , "import Json.Decode exposing ((:=))"
@@ -37,6 +47,12 @@ makeElmModule moduleName defs = unlines (
     , ""
     ]) ++ makeModuleContent defs
 
+-- | Creates an Elm module. This will use the default type conversion rules (to
+-- convert @Vector@ to @List@, @HashMap a b@ to @List (a,b)@, etc.).
+makeElmModule :: String -- ^ Module name
+              -> [DefineElm] -- ^ List of definitions to be included in the module
+              -> String
+makeElmModule = makeElmModuleWithVersion Elm0p16
 
 -- | Generates the content of a module. You will be responsible for
 -- including the required Elm headers. This uses the default type

--- a/src/Elm/Module.hs
+++ b/src/Elm/Module.hs
@@ -24,7 +24,7 @@ makeElmModule :: String -- ^ Module name
               -> [DefineElm] -- ^ List of definitions to be included in the module
               -> String
 makeElmModule moduleName defs = unlines (
-    [ "module " ++ moduleName ++ " exposing(..)"
+    [ "module " ++ moduleName ++ " where"
     , ""
     , "import Json.Decode"
     , "import Json.Decode exposing ((:=))"

--- a/src/Elm/Versions.hs
+++ b/src/Elm/Versions.hs
@@ -1,0 +1,7 @@
+{-| A type to represent versions of Elm for produced code to work against
+-}
+module Elm.Versions where
+
+data ElmVersion
+  = Elm0p16
+  | Elm0p17

--- a/test/Elm/ModuleSpec.hs
+++ b/test/Elm/ModuleSpec.hs
@@ -27,7 +27,7 @@ $(deriveElmDef (defaultOptionsDropLower 5) ''Qux)
 
 moduleCode :: String
 moduleCode = unlines
-    [ "module Foo exposing(..)"
+    [ "module Foo where"
     , ""
     , "import Json.Decode"
     , "import Json.Decode exposing ((:=))"
@@ -69,7 +69,7 @@ moduleCode = unlines
 
 moduleCode' :: String
 moduleCode' = unlines
-    [ "module Qux exposing(..)"
+    [ "module Qux where"
     , ""
     , "import Json.Decode"
     , "import Json.Decode exposing ((:=))"

--- a/test/Elm/ModuleSpec.hs
+++ b/test/Elm/ModuleSpec.hs
@@ -27,7 +27,7 @@ $(deriveElmDef (defaultOptionsDropLower 5) ''Qux)
 
 moduleCode :: String
 moduleCode = unlines
-    [ "module Foo where"
+    [ "module Foo exposing(..)"
     , ""
     , "import Json.Decode"
     , "import Json.Decode exposing ((:=))"
@@ -69,7 +69,7 @@ moduleCode = unlines
 
 moduleCode' :: String
 moduleCode' = unlines
-    [ "module Qux where"
+    [ "module Qux exposing(..)"
     , ""
     , "import Json.Decode"
     , "import Json.Decode exposing ((:=))"

--- a/test/EndToEnd.hs
+++ b/test/EndToEnd.hs
@@ -121,7 +121,7 @@ elmModuleContent = unlines
     [ "-- This module requires the following packages:"
     , "-- * deadfoxygrandpa/elm-test"
     , "-- * bartavelle/json-helpers"
-    , "module MyTests where"
+    , "module MyTests exposing(..)"
     , ""
     , "import Dict exposing (Dict)"
     , "import Set exposing (Set)"

--- a/test/EndToEnd.hs
+++ b/test/EndToEnd.hs
@@ -121,7 +121,7 @@ elmModuleContent = unlines
     [ "-- This module requires the following packages:"
     , "-- * deadfoxygrandpa/elm-test"
     , "-- * bartavelle/json-helpers"
-    , "module MyTests exposing(..)"
+    , "module MyTests where"
     , ""
     , "import Dict exposing (Dict)"
     , "import Set exposing (Set)"


### PR DESCRIPTION
I have changed the header in generated modules to read 'exposing(..)' rather then 'where', in line with Elm version 0.17.

However, should the be able to be switched for backward compatibility?