### PR TITLE
Switched from (:=) to Json.Decode.field

### DIFF
--- a/src/Elm/Json.hs
+++ b/src/Elm/Json.hs
@@ -72,7 +72,7 @@ parseRecords newtyped unwrap fields = map (mkField doUnwrap) fields ++ ["   Json
            let (fldStart, fldEnd, mh) = if isOption fldType
                                             then ("(Json.Decode.maybe ", ")", Root)
                                             else ("", "", Leaf)
-           in   "   " ++ fldStart ++ "(" ++ (if u then "" else "\"" ++ fldName ++ "\" := ")
+           in   "   " ++ fldStart ++ "(" ++ (if u then "" else "Json.Decode.field \"" ++ fldName ++ "\" ")
                       ++ jsonParserForType' mh fldType
                       ++ fldEnd
                       ++ ") >>= \\p" ++ fldName ++ " ->"

--- a/src/Elm/Module.hs
+++ b/src/Elm/Module.hs
@@ -36,7 +36,8 @@ makeElmModuleWithVersion elmVersion moduleName defs = unlines (
     [ moduleHeader elmVersion moduleName
     , ""
     , "import Json.Decode"
-    , "import Json.Decode exposing ((:=))"
+    , "-- This has been now replaced by Json.Decode.field"
+    , "-- import Json.Decode exposing ((:=))"
     , "import Json.Encode exposing (Value)"
     , "-- The following module comes from bartavelle/json-helpers"
     , "import Json.Helpers exposing (..)"


### PR DESCRIPTION
Elm core 5.0.0 replaces the operator := with function
Json.Decode.field. This patches Elm-bridge to be compatible
with 5.0.0.

I don't know what's your strategy of supporting multiple elm versions, but
naturally, elm core 3 or 4 will not compile the results after merging this. Merge
if you follow the latest.