### PR TITLE
Added possibility of specifying imports

### DIFF
--- a/src/Elm/Module.hs
+++ b/src/Elm/Module.hs
@@ -32,7 +32,14 @@ makeElmModuleWithVersion :: ElmVersion
                          -> String  -- ^ Module name
                          -> [DefineElm]  -- ^ List of definitions to be included in the module
                          -> String
-makeElmModuleWithVersion elmVersion moduleName defs = unlines (
+makeElmModuleWithVersion elmVersion moduleName defs =  makeElmModuleWithVersionAndImports elmVersion moduleName [] defs
+
+makeElmModuleWithVersionAndImports :: ElmVersion
+                         -> String  -- ^ Module name
+                         -> [String] -- ^ Module names to import
+                         -> [DefineElm]  -- ^ List of definitions to be included in the module
+                         -> String
+makeElmModuleWithVersionAndImports elmVersion moduleName importList defs = unlines (
     [ moduleHeader elmVersion moduleName
     , ""
     , "import Json.Decode"
@@ -41,9 +48,9 @@ makeElmModuleWithVersion elmVersion moduleName defs = unlines (
     , "import Json.Helpers exposing (..)"
     , "import Dict"
     , "import Set"
-    , ""
-    , ""
-    ]) ++ makeModuleContent defs
+    ] ++ map ("import "++) importList
+      ++ ["",""])
+      ++ makeModuleContent defs
 
 -- | Creates an Elm module. This will use the default type conversion rules (to
 -- convert @Vector@ to @List@, @HashMap a b@ to @List (a,b)@, etc.).

--- a/src/Elm/Module.hs
+++ b/src/Elm/Module.hs
@@ -110,6 +110,7 @@ defaultAlterations = recAlterType $ \t -> case t of
                                   ETyApp (ETyApp (ETyCon (ETCon "THashMap")) k) v -> checkMap k v
                                   ETyApp (ETyApp (ETyCon (ETCon "Map")) k) v      -> checkMap k v
                                   ETyCon (ETCon "Integer")                        -> ETyCon (ETCon "Int")
+                                  ETyCon (ETCon "Natural")                        -> ETyCon (ETCon "Int")
                                   ETyCon (ETCon "Text")                           -> ETyCon (ETCon "String")
                                   ETyCon (ETCon "Vector")                         -> ETyCon (ETCon "List")
                                   ETyCon (ETCon "Double")                         -> ETyCon (ETCon "Float")


### PR DESCRIPTION
I have a bigger project that has multiple modules that need to interact with Elm. Most of the modules have distinct types but some types are shared. I couldn't figure out how to export this 'commons' module only once without having the other, generated, modules import it.

So, here is a way to add imports to generated modules. 

Was there a pre-existing way to do something like this? If yes, point me towards it and I'll submit a doc-patch instead ;) 