### PR TITLE
Fixes #31. Exposing and adding EType functions for servant-elm.

### DIFF
--- a/src/Elm/Json.hs
+++ b/src/Elm/Json.hs
@@ -9,6 +9,8 @@ The reason is that Elm types might have an equivalent on the Haskell side and sh
 module Elm.Json
     ( jsonParserForDef
     , jsonSerForDef
+    , jsonParserForType
+    , jsonSerForType
     )
 where
 
@@ -22,6 +24,7 @@ import Elm.Utils
 data MaybeHandling = Root | Leaf
                    deriving Eq
 
+-- | Compile a JSON parser for an Elm type
 jsonParserForType :: EType -> String
 jsonParserForType = jsonParserForType' Leaf
 
@@ -29,7 +32,6 @@ isOption :: EType -> Bool
 isOption (ETyApp (ETyCon (ETCon "Maybe")) _) = True
 isOption _ = False
 
--- | Compile a JSON parser for an Elm type
 jsonParserForType' :: MaybeHandling -> EType -> String
 jsonParserForType' mh ty =
     case ty of


### PR DESCRIPTION
So, here is my proposal for issue #31, which I submitted a couple of weeks ago. I spent some more time thinking about the issue, and came to the conclusion that I was over complicating it. For purposes of the `servant` code generator, I just need a way to get the name of an Elm type, and get it's JSON serializer and deserializer. 

I  have exposed a couple of functions that you already have (jsonParserForType/jsonSerForType) for the JSON bits, and then wrote a function to do  `Proxy a -> EType`. Most of the logic in this function was taken from the `Derive` module, which unfortunately means it (sort of) exists in two different places now.

I also made `defaultAlterations` recurse `ETyApp`, because I wanted to make sure that `Map Text Foo` would get transformed into `Dict String Foo` on the Elm side, for example.

Please let me know what you think!