### PR TITLE
Adding support for the unit type.

### DIFF
--- a/src/Elm/TyRep.hs
+++ b/src/Elm/TyRep.hs
@@ -87,6 +87,7 @@ unpackTupleType et = fromMaybe [et] (extract et)
     where
         extract :: EType -> Maybe [EType]
         extract ty = case ty of
+                         ETyTuple 0 -> return []
                          ETyApp (ETyTuple _) t -> return [t]
                          ETyApp app@(ETyApp _ _) t -> fmap (++ [t]) (extract app)
                          _ -> Nothing

--- a/test/Elm/TyRenderSpec.hs
+++ b/test/Elm/TyRenderSpec.hs
@@ -26,9 +26,15 @@ data SomeOpts a
    = Okay Int
    | NotOkay a
 
+data Unit
+   = Unit
+   { u_unit :: ()
+   }
+
 $(deriveElmDef (defaultOptionsDropLower 2) ''Foo)
 $(deriveElmDef (defaultOptionsDropLower 2) ''Bar)
 $(deriveElmDef defaultOptions ''SomeOpts)
+$(deriveElmDef defaultOptions ''Unit)
 
 fooCode :: String
 fooCode = "type alias Foo  =\n   { name: String\n   , blablub: Int\n   }\n"
@@ -39,13 +45,18 @@ barCode = "type alias Bar a =\n   { name: a\n   , blablub: Int\n   , tuple: (Int
 someOptsCode :: String
 someOptsCode = "type SomeOpts a =\n    Okay Int\n    | NotOkay a\n"
 
+unitCode :: String
+unitCode = "type alias Unit  =\n   { u_unit: ()\n   }\n"
+
 spec :: Spec
 spec =
     describe "deriveElmRep" $
     do let rFoo = compileElmDef (Proxy :: Proxy Foo)
            rBar = compileElmDef (Proxy :: Proxy (Bar a))
            rSomeOpts = compileElmDef (Proxy :: Proxy (SomeOpts a))
+           rUnit = compileElmDef (Proxy :: Proxy Unit)
        it "should produce the correct code" $
           do renderElm rFoo `shouldBe` fooCode
              renderElm rBar `shouldBe` barCode
              renderElm rSomeOpts `shouldBe` someOptsCode
+             renderElm rUnit `shouldBe` unitCode


### PR DESCRIPTION
Hi again. This is a follow-up to my previous PR (#33). The reason for this PR is that a servant API can result in a client function that returns unit (ie. a POST request that returns no content).

I couldn't think of any unforseen side-effects of this change, but let me know if you have any issues with it.