### PR TITLE
Fix `toElmType` for tuple type

### DIFF
--- a/elm-bridge.cabal
+++ b/elm-bridge.cabal
@@ -59,6 +59,7 @@ test-suite derive-elm-tests
                        Elm.TyRenderSpec
                        Elm.JsonSpec
                        Elm.ModuleSpec
+                       Elm.TyRepSpec
   build-depends:
                        base,
                        hspec >= 2.0,

--- a/src/Elm/TyRep.hs
+++ b/src/Elm/TyRep.hs
@@ -175,7 +175,7 @@ toElmType ty = toElmType' $ typeRep ty
             -- List is special because the constructor name is [] in Haskell and List in elm
           | con == (typeRepTyCon $ typeRep (Proxy :: Proxy [])) = ETyApp (ETyCon $ ETCon $ "List") (toElmType' (head args))
             -- The unit type '()' is a 0-ary tuple.
-          | isTuple $ tyConName con = ETyTuple $ length args
+          | isTuple $ tyConName con = foldl ETyApp (ETyTuple $ length args) $ map toElmType' args
           | otherwise = typeApplication con args
             where
                 (con, args) = splitTyConApp rep

--- a/test/Elm/TyRepSpec.hs
+++ b/test/Elm/TyRepSpec.hs
@@ -1,0 +1,21 @@
+module Elm.TyRepSpec (spec) where
+
+import Elm.TyRep
+
+import Data.Proxy
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "toElmType" $
+      it "should produce the correct code" $
+      do toElmType (Proxy :: Proxy Int) `shouldBe` ETyCon (ETCon "Int")
+         toElmType (Proxy :: Proxy Float) `shouldBe` ETyCon (ETCon "Float")
+         toElmType (Proxy :: Proxy String) `shouldBe` ETyCon (ETCon "String")
+         toElmType (Proxy :: Proxy Bool) `shouldBe` ETyCon (ETCon "Bool")
+         toElmType (Proxy :: Proxy Char) `shouldBe` ETyCon (ETCon "Char")
+         toElmType (Proxy :: Proxy [Int]) `shouldBe` ETyApp (ETyCon $ ETCon "List") (ETyCon $ ETCon "Int")
+         toElmType (Proxy :: Proxy (Maybe Int)) `shouldBe` ETyApp (ETyCon $ ETCon "Maybe") (ETyCon $ ETCon "Int")
+         toElmType (Proxy :: Proxy ()) `shouldBe` ETyTuple 0
+         toElmType (Proxy :: Proxy (Int, Bool)) `shouldBe` ETyApp (ETyApp (ETyTuple 2) (ETyCon $ ETCon "Int")) (ETyCon $ ETCon "Bool")
+         toElmType (Proxy :: Proxy (Int, Bool, String)) `shouldBe` ETyApp (ETyApp (ETyApp (ETyTuple 3) (ETyCon $ ETCon "Int")) (ETyCon $ ETCon "Bool")) (ETyCon $ ETCon "String")

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,6 +4,7 @@ import qualified Elm.DeriveSpec
 import qualified Elm.TyRenderSpec
 import qualified Elm.JsonSpec
 import qualified Elm.ModuleSpec
+import qualified Elm.TyRepSpec
 
 import Test.Hspec
 
@@ -13,3 +14,4 @@ main = hspec $ do
   describe "Elm.TyRenderSpec" Elm.TyRenderSpec.spec
   describe "Elm.JsonSpec" Elm.JsonSpec.spec
   describe "Elm.ModuleSpec" Elm.ModuleSpec.spec
+  describe "Elm.TyRepSpec" Elm.TyRepSpec.spec


### PR DESCRIPTION
use `toElmType` for Tuple type

```haskell
ghci> import Data.Proxy
ghci> toElmType (Proxy :: Proxy Int)
ETyCon (ETCon {tc_name = "Int"})
ghci> toElmType (Proxy :: Proxy (Int, Int))
ETyTuple 2
```

I think to expect `ETyApp (ETyApp (ETyTuple 2) (ETyCon $ ETCon "Int")) (ETyCon $ ETCon "Int")` instead of `ETyTuple 2`.

So, fixed `toElmType` definition (and add spec).