### PR TITLE
Add functions to generate ADT String parsers/renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ jsonEncFoo  val =
    ]
 ```
 
+Also, there are functions `Elm.Json.stringSerForSimpleAdt` and `Elm.Json.stringParserForSimpleAdt` to generate functions for your non-JSON ADT types.
+
 For more usage examples check the tests or the examples dir.
 
 ## Install

--- a/src/Elm/Json.hs
+++ b/src/Elm/Json.hs
@@ -273,7 +273,7 @@ stringSerForSimpleAdt etd =
       where
         defaultEncoding os =
           unlines
-            ((makeName name False ++ " =") : "    case v of" : map mkcase os)
+            ((makeName name False ++ " =") : "    case val of" : map mkcase os)
         mkcase :: SumTypeConstructor -> String
         mkcase (STC cname oname (Anonymous args)) =
           replicate 8 ' '
@@ -308,25 +308,27 @@ stringSerForSimpleAdt etd =
 stringParserForSimpleAdt :: ETypeDef -> String
 stringParserForSimpleAdt etd =
   case etd of
-    ETypeSum (ESum name opts (SumEncoding' _encodingType) _ unarystring) ->
+    ETypeSum (ESum name opts (SumEncoding' _encodingType) _ _unarystring) ->
       decoderType name
         ++ "\n"
         ++ makeName name
-        ++ " s ="
-        ++ case allUnaries unarystring opts of
-          Just names -> " " ++ deriveUnaries names
-          Nothing -> "\n" ++ encodingDictionary opts ++ "\n"
+        ++ " s =\n"
+        ++ encodingDictionary opts
+        ++ "\n"
+        -- ++ case allUnaries unarystring opts of
+        --   Just names -> " " ++ deriveUnaries names
+        --   Nothing -> "\n" ++ encodingDictionary opts ++ "\n"
       where
         tab n s = replicate n ' ' ++ s
-        deriveUnaries strs =
-          unlines
-            [ "",
-              "case s of",
-              intercalate
-                ", "
-                (map (\(o, s) -> "(" ++ show s ++ ", " ++ o ++ ")") strs)
-                ++ "]"
-            ]
+        -- deriveUnaries strs =
+        --   unlines
+        --     [ "",
+        --       "case s of",
+        --       intercalate
+        --         ", "
+        --         (map (\(o, s) -> "(" ++ show s ++ ", " ++ o ++ ")") strs)
+        --         ++ "]"
+        --     ]
         encodingDictionary [STC cname _ args] =
           "    " ++ mkDecoder cname args
         encodingDictionary os =

--- a/src/Elm/Json.hs
+++ b/src/Elm/Json.hs
@@ -11,6 +11,8 @@ module Elm.Json
     , jsonSerForDef
     , jsonParserForType
     , jsonSerForType
+    , stringSerForSimpleAdt
+    , stringParserForSimpleAdt
     )
 where
 
@@ -253,3 +255,97 @@ jsonSerForDef etd =
            ++ if newtyping
                   then " (" ++ et_name name ++ " val)"
                   else " val"
+
+-- | Serialize a type like 'type Color = Red | Green | Blue' in a function like
+--
+--     stringEncColor : Color -> String
+--     stringEncColor x =
+--       case x of
+--         Red -> "red"
+--         ...
+--
+-- This is mainly useful for types which are used as part of query parameters and url captures.
+stringSerForSimpleAdt :: ETypeDef -> String
+stringSerForSimpleAdt etd =
+  case etd of
+    ETypeSum (ESum name opts (SumEncoding' _se) _ _unarystring) ->
+      defaultEncoding opts
+      where
+        defaultEncoding os =
+          unlines
+            ((makeName name False ++ " =") : "    case v of" : map mkcase os)
+        mkcase :: SumTypeConstructor -> String
+        mkcase (STC cname oname (Anonymous args)) =
+          replicate 8 ' '
+            ++ cap cname
+            ++ " "
+            ++ argList args
+            ++ " -> "
+            ++ show oname
+        mkcase _ =
+          error "stringSerForSimpleAdt.mkcase: Expecting an Anonymous case"
+        argList a = unwords $ map (\i -> "v" ++ show i) [1 .. length a]
+    _ -> error "stringSerForSimpleAdt only works with ETypeSum"
+  where
+    fname name = "stringEnc" ++ et_name name
+    makeType name =
+      fname name
+        ++ " : "
+        ++ intercalate
+          " -> "
+          ([unwords (et_name name : map tv_name (et_args name))] ++ ["String"])
+    makeName name newtyping =
+      makeType name
+        ++ "\n"
+        ++ fname name
+        ++ " "
+        ++ unwords (map (\tv -> "localEncoder_" ++ tv_name tv) $ et_args name)
+        ++ if newtyping
+          then " (" ++ et_name name ++ " val)"
+          else " val"
+
+-- | Parse a String into a maybe-value for simple ADT types. See 'stringSerForSimpleAdt' for motivation
+stringParserForSimpleAdt :: ETypeDef -> String
+stringParserForSimpleAdt etd =
+  case etd of
+    ETypeSum (ESum name opts (SumEncoding' _encodingType) _ unarystring) ->
+      decoderType name
+        ++ "\n"
+        ++ makeName name
+        ++ " s ="
+        ++ case allUnaries unarystring opts of
+          Just names -> " " ++ deriveUnaries names
+          Nothing -> "\n" ++ encodingDictionary opts ++ "\n"
+      where
+        tab n s = replicate n ' ' ++ s
+        deriveUnaries strs =
+          unlines
+            [ "",
+              "case s of",
+              intercalate
+                ", "
+                (map (\(o, s) -> "(" ++ show s ++ ", " ++ o ++ ")") strs)
+                ++ "]"
+            ]
+        encodingDictionary [STC cname _ args] =
+          "    " ++ mkDecoder cname args
+        encodingDictionary os =
+          "    case s of\n"
+            ++ tab 8 ""
+            ++ intercalate ("\n" ++ replicate 8 ' ') (map dictEntry os)
+            ++ "\n"
+            ++ tab 8 "_ -> Nothing"
+        dictEntry (STC cname oname _args) =
+          show oname ++ " -> Just " ++ cname
+        mkDecoder _cname _ = error "impossible!"
+    _ -> error "impossible"
+  where
+    funcname name = "stringDec" ++ et_name name
+    prependTypes str = map (\tv -> str ++ tv_name tv) . et_args
+    decoderType name =
+      funcname name
+        ++ " : "
+        ++ intercalate " -> " (["String"] ++ [decoderTypeEnd name])
+    decoderTypeEnd name =
+      unwords ("Maybe" : et_name name : map tv_name (et_args name))
+    makeName name = unwords (funcname name : prependTypes "localDecoder_" name)

--- a/src/Elm/Json.hs
+++ b/src/Elm/Json.hs
@@ -258,11 +258,11 @@ jsonSerForDef etd =
 
 -- | Serialize a type like 'type Color = Red | Green | Blue' in a function like
 --
---     stringEncColor : Color -> String
---     stringEncColor x =
---       case x of
---         Red -> "red"
---         ...
+-- > stringEncColor : Color -> String
+-- > stringEncColor x =
+-- >   case x of
+-- >     Red -> "red"
+-- >     ...
 --
 -- This is mainly useful for types which are used as part of query parameters and url captures.
 stringSerForSimpleAdt :: ETypeDef -> String
@@ -315,20 +315,8 @@ stringParserForSimpleAdt etd =
         ++ " s =\n"
         ++ encodingDictionary opts
         ++ "\n"
-        -- ++ case allUnaries unarystring opts of
-        --   Just names -> " " ++ deriveUnaries names
-        --   Nothing -> "\n" ++ encodingDictionary opts ++ "\n"
       where
         tab n s = replicate n ' ' ++ s
-        -- deriveUnaries strs =
-        --   unlines
-        --     [ "",
-        --       "case s of",
-        --       intercalate
-        --         ", "
-        --         (map (\(o, s) -> "(" ++ show s ++ ", " ++ o ++ ")") strs)
-        --         ++ "]"
-        --     ]
         encodingDictionary [STC cname _ args] =
           "    " ++ mkDecoder cname args
         encodingDictionary os =

--- a/test/Elm/JsonSpec.hs
+++ b/test/Elm/JsonSpec.hs
@@ -209,7 +209,7 @@ unaryAStringSer :: String
 unaryAStringSer = unlines
     [ "stringEncUnaryA : UnaryA -> String"
     , "stringEncUnaryA  val ="
-    , "    case v of"
+    , "    case val of"
     , "        UnaryA1  -> \"UnaryA1\""
     , "        UnaryA2  -> \"UnaryA2\""
     ]

--- a/test/Elm/JsonSpec.hs
+++ b/test/Elm/JsonSpec.hs
@@ -177,6 +177,16 @@ unaryAParse = unlines
     , "    in  decodeSumObjectWithSingleField  \"UnaryA\" jsonDecDictUnaryA"
     ]
 
+unaryAStringParser :: String
+unaryAStringParser = unlines
+    [ "stringDecUnaryA : String -> Maybe UnaryA"
+    , "stringDecUnaryA s ="
+    , "    case s of"
+    , "        \"UnaryA1\" -> Just UnaryA1"
+    , "        \"UnaryA2\" -> Just UnaryA2"
+    , "        _ -> Nothing"
+    ]
+
 unaryBParse :: String
 unaryBParse = unlines
     [ "jsonDecUnaryB : Json.Decode.Decoder ( UnaryB )"
@@ -193,6 +203,15 @@ unaryASer = unlines
     , "                    UnaryA1  -> (\"UnaryA1\", encodeValue (Json.Encode.list identity []))"
     , "                    UnaryA2  -> (\"UnaryA2\", encodeValue (Json.Encode.list identity []))"
     , "    in encodeSumObjectWithSingleField keyval val"
+    ]
+
+unaryAStringSer :: String
+unaryAStringSer = unlines
+    [ "stringEncUnaryA : UnaryA -> String"
+    , "stringEncUnaryA  val ="
+    , "    case v of"
+    , "        UnaryA1  -> \"UnaryA1\""
+    , "        UnaryA2  -> \"UnaryA2\""
     ]
 
 unaryBSer :: String
@@ -312,6 +331,10 @@ spec =
        it "should produce the correct ser code for unary unions" $ do
              jsonSerForDef rUnaryA `shouldBe` unaryASer
              jsonSerForDef rUnaryB `shouldBe` unaryBSer
+       it "should produce the correct stringSerForSimpleAdt code" $ do
+             stringSerForSimpleAdt rUnaryA `shouldBe` unaryAStringSer
+       it "should produce the correct stringParserForDef code" $ do
+             stringParserForSimpleAdt rUnaryA `shouldBe` unaryAStringParser
        it "should produce the correct parse code for aliases" $ do
              jsonParserForDef rFoo `shouldBe` fooParse
              jsonParserForDef rBar `shouldBe` barParse


### PR DESCRIPTION
This can be considered as a design proposal or a request for feedback (even though I'll be using this code in production straight away).

I don't know if it's worth adding the actual code in README or just mentioning the functions is enough.

The point of this code is to use it for things like query parameters in your REST API. Previously we've had to manually add encoders/decoders for them.

Feedback welcome!