### PR TITLE
added: .gitignore created by toptal.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,62 @@
+# Created by https://www.toptal.com/developers/gitignore/api/haskell,macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=haskell,macos
+
+### Haskell ###
 dist
+dist-*
 cabal-dev
 *.o
 *.hi
+*.hie
 *.chi
 *.chs.h
-.virthualenv
-.DS_Store
-.cabal-sandbox
-cabal.sandbox.config
-*~
-.stack-work
 *.dyn_o
 *.dyn_hi
-stack.yaml
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/haskell,macos


### PR DESCRIPTION
Because cabal v2-build creates a dist-newstyle and it is depressing that it is being tracked.